### PR TITLE
Fixes test cases

### DIFF
--- a/playwright-tests/storage-states/admin-connected.json
+++ b/playwright-tests/storage-states/admin-connected.json
@@ -1,0 +1,27 @@
+{
+  "cookies": [],
+  "origins": [
+    {
+      "origin": "http://localhost:8080",
+      "localStorage": [
+        {
+          "name": "near-wallet-selector:selectedWalletId",
+          "value": "\"my-near-wallet\""
+        },
+        {
+          "name": "near_app_wallet_auth_key",
+          "value": "{\"accountId\":\"lachlan.near\"}"
+        },
+        {
+          "name": "near-social-vm:v01::accountId:",
+          "value": "lachlan.near"
+        },
+        {
+          "name": "flags",
+          "value": "{\"bosLoaderUrl\":\"http://127.0.0.1:3030\"}"
+        }
+      ]
+    }
+  ],
+  "sessionStorage": []
+}

--- a/playwright-tests/tests/pots.spec.js
+++ b/playwright-tests/tests/pots.spec.js
@@ -20,16 +20,11 @@ test("clicking pot card should go to pot page", async ({ page }) => {
 });
 
 test("clicking deploy button should go to deploypot page", async ({ page }) => {
-  
   const deployButton = await page.getByText("Deploy");
 
-  await Promise.all([
-    deployButton.click(),
-    page.waitForNavigation({ waitUntil: 'networkidle' }) 
-  ]);
+  await Promise.all([deployButton.click(), page.waitForNavigation({ waitUntil: "networkidle" })]);
 
   expect(page.url()).toContain("/deploypot");
-
 });
 
 test("clicking learn more button should...", async ({ page }) => {

--- a/playwright-tests/tests/pots.spec.js
+++ b/playwright-tests/tests/pots.spec.js
@@ -5,11 +5,8 @@
 import { test, expect } from "@playwright/test";
 import { ROOT_SRC, DEFAULT_POT_ID } from "../util/constants";
 
-test.beforeEach(async ({ page }) => {
-  await page.goto(`${ROOT_SRC}?tab=pots`);
-});
-
 test("clicking pot card should go to pot page", async ({ page }) => {
+  await page.goto(`${ROOT_SRC}?tab=pots`);
   const potCard = await page.getByText("NEAR Retroactive Builders");
 
   await Promise.all([potCard.click(), page.waitForLoadState("load")]);
@@ -19,12 +16,36 @@ test("clicking pot card should go to pot page", async ({ page }) => {
   expect(url).toContain(`?tab=pot&potId=${DEFAULT_POT_ID}`);
 });
 
-test("clicking deploy button should go to deploypot page", async ({ page }) => {
-  const deployButton = await page.getByText("Deploy");
+test.describe("User is not logged in", () => {
+  test.use({
+    storageState: "playwright-tests/storage-states/wallet-not-connected.json",
+  });
 
-  await Promise.all([deployButton.click(), page.waitForNavigation({ waitUntil: "networkidle" })]);
+  test("deploy button should not be visible", async ({ page }) => {
+    await page.goto(`${ROOT_SRC}?tab=pots`);
 
-  expect(page.url()).toContain("/deploypot");
+    // Check if the deploy button is not visible
+    const deployButton = await page.$('a:has-text("Deploy Pot")');
+
+    // Assert that the deploy button is not visible
+    expect(deployButton).toBeNull();
+  });
+});
+
+test.describe("Admin is logged in", () => {
+  test.use({
+    storageState: "playwright-tests/storage-states/admin-connected.json",
+  });
+
+  test("deploy button should go to deploypot page", async ({ page }) => {
+    await page.goto(`${ROOT_SRC}?tab=pots`);
+
+    const deployButton = await page.getByRole("link", { name: "Deploy Pot" });
+
+    await Promise.all([deployButton.click(), page.waitForLoadState("load")]);
+
+    expect(page.url()).toContain("?tab=deploypot");
+  });
 });
 
 test("clicking learn more button should...", async ({ page }) => {


### PR DESCRIPTION
I noticed that "Deploy Pot" is only visible for admin accounts, and so this is why your test was failing.

I've added storage states (connected, not-connected, and admin) that can be configured for individual tests

Also -- remember to `npm run fmt` to format your code before you push!


If you merge this PR, then we can merge your PR into Potlock